### PR TITLE
use a pipeline that is half-open friendly

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "dependencies": {
     "@hyperswarm/dht": "next",
     "heapdump": "^0.3.15",
-    "minimist": "^1.2.5",
-    "pump": "^3.0.0"
+    "minimist": "^1.2.5"
   },
   "devDependencies": {},
   "bin": {


### PR DESCRIPTION
With the pump one, if the local connection closed the writable side before it closed the readable side, a race condition happen where the readable packet might be lost.