### PR TITLE
Sever can specify an `allow` list of key pairs to accept connections from

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ hypertele-server --gen_seed
 Create a JSON config file for your server
 ```
 {
-  "seed": "SEED_ABOVE"
+  "seed": "SEED_ABOVE",
+  "allowed": [
+    "REMOTE_PUBLIC_KEY",
+    ...
+  ]
 }
 ```
 
@@ -27,6 +31,10 @@ hypertele-server -l 7001 -c config-server.json
 
 ### client
 
+```
+hypertele --gen_keypair keypair.json
+```
+
 Create a JSON config file for your client
 ```
 {
@@ -35,6 +43,6 @@ Create a JSON config file for your client
 ```
 
 ```
-hypertele -p 1337 -c config-client.json
+hypertele -p 1337 -c config-client.json -k keypair.json
 telnet localhost 1337
 ```

--- a/README.md
+++ b/README.md
@@ -38,11 +38,19 @@ hypertele --gen_keypair keypair.json
 Create a JSON config file for your client
 ```
 {
-  "peer": "PUBKEY_FROM_SERVER"
+  "peer": "PUBKEY_FROM_SERVER",
+  "keyfile": "./keyfile.json"
 }
 ```
 
 ```
-hypertele -p 1337 -c config-client.json -k keypair.json
+hypertele -p 1337 -c config-client.json
+telnet localhost 1337
+```
+
+A server key can also be specified using `-s` CLI arg. Similarly, keyfile can be passed under `-k` CLI arg.
+
+```
+hypertele -p 1337 -s PUBKEY_FROM_SERVER -k keypair.json
 telnet localhost 1337
 ```

--- a/client.js
+++ b/client.js
@@ -5,7 +5,7 @@ const fs = require('fs')
 const argv = require('minimist')(process.argv.slice(2))
 const connHandler = require('./lib.js').connHandler
 
-const helpMsg = 'Usage:\nhyperproxy -p port_listen -c conf.json [-k keypair.json]'
+const helpMsg = 'Usage:\nhyperproxy -p port_listen -c conf.json -k keypair.json -s server_key'
 
 if (argv.gen_keypair) {
   const kp = HyperDHT.keyPair()
@@ -39,8 +39,9 @@ try {
   process.exit(-1)
 }
 
-if (!conf.peer) {
-  console.error('Error: conf.peer invalid')
+const peer = argv.s || conf.peer
+if (!peer) {
+  console.error('Error: peer is invalid')
   process.exit(-1)
 }
 
@@ -55,7 +56,7 @@ const stats = {}
 
 const proxy = net.createServer({ allowHalfOpen: true }, c => {
   return connHandler(c, () => {
-    return dht.connect(Buffer.from(conf.peer, 'hex'))
+    return dht.connect(Buffer.from(peer, 'hex'))
   }, {}, stats)
 })
 
@@ -65,6 +66,7 @@ if (debug) {
   }, 5000)
 }
 
+const keyfile = argv.k || conf.keyfile
 proxy.listen(+argv.p, () => {
   console.log(`Server ready @${argv.p}`)
 })

--- a/client.js
+++ b/client.js
@@ -46,8 +46,9 @@ if (!conf.peer) {
 
 const debug = argv.debug
 
+const keyfile = argv.k || conf.keyfile
 const dht = new HyperDHT({
-  keyPair: argv.k && parseKeyPair(fs.readFileSync(argv.k))
+  keyPair: keyfile && parseKeyPair(fs.readFileSync(keyfile))
 })
 
 const stats = {}

--- a/lib.js
+++ b/lib.js
@@ -1,6 +1,17 @@
 module.exports = {
   connHandler: (connection, _dst, opts = {}, stats = {}) => {
     const loc = _dst()
+    if (loc === null) {
+      connection.destroy() // don't return rejection error
+
+      if (!stats.rejectCnt) {
+        stats.rejectCnt = 0
+      }
+
+      stats.rejectCnt++
+
+      return
+    }
 
     if (!stats.locCnt) {
       stats.locCnt = 0

--- a/server.js
+++ b/server.js
@@ -63,7 +63,7 @@ const stats = {}
 
 const server = dht.createServer(c => {
   return connHandler(c, () => {
-    if (allow !== null && !find(allow, c.remotePublicKey)) return
+    if (allow !== null && !find(allow, c.remotePublicKey)) return null
     return net.connect({ port: +argv.l, host: '127.0.0.1', allowHalfOpen: true })
   }, { debug: debug }, stats)
 })
@@ -89,5 +89,5 @@ function randomBytes (n) {
 }
 
 function find (arr, buf) {
-  return arr.findIndex(k => k.equals(buf)) < 0
+  return arr.findIndex(k => k.equals(buf)) >= 0
 }

--- a/server.js
+++ b/server.js
@@ -47,6 +47,11 @@ if (!conf.seed) {
   process.exit(-1)
 }
 
+let allow = null
+if (conf.allow) {
+  allow = conf.allow.map(pk => Buffer.from(pk, 'hex'))
+}
+
 const debug = argv.debug
 
 const seed = Buffer.from(conf.seed, 'hex')
@@ -58,6 +63,7 @@ const stats = {}
 
 const server = dht.createServer(c => {
   return connHandler(c, () => {
+    if (allow !== null && !find(allow, c.remotePublicKey)) return
     return net.connect({ port: +argv.l, host: '127.0.0.1', allowHalfOpen: true })
   }, { debug: debug }, stats)
 })
@@ -80,4 +86,8 @@ function randomBytes (n) {
   const b = Buffer.alloc(n)
   sodium.randombytes_buf(b)
   return b
+}
+
+function find (arr, buf) {
+  return arr.findIndex(k => k.equals(buf)) < 0
 }


### PR DESCRIPTION
This PR allows a client to generate a key pair and store it a file. The public key is then passed to an operator and they may add it to `server.conf.allow`.

The client may then specify which key pair to be used when connecting a server.