### PR TITLE
Use graceful-goodbye + make pub close server on exit

### DIFF
--- a/client.js
+++ b/client.js
@@ -5,6 +5,7 @@ const argv = require('minimist')(process.argv.slice(2))
 const libNet = require('@hyper-cmd/lib-net')
 const libUtils = require('@hyper-cmd/lib-utils')
 const libKeys = require('@hyper-cmd/lib-keys')
+const goodbye = require('graceful-goodbye')
 const connPiper = libNet.connPiper
 
 const helpMsg = 'Usage:\nhypertele -p port_listen -u unix_socket ?-c conf.json ?-i identity.json ?-s peer_key'
@@ -88,8 +89,6 @@ proxy.listen(target, () => {
   console.log(`Server ready @${target}`)
 })
 
-process.once('SIGINT', () => {
-  dht.destroy().then(() => {
-    process.exit()
-  })
+goodbye(async () => {
+  await dht.destroy()
 })

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "TCP proxy over Hyperswarm!",
   "main": "index.js",
   "dependencies": {
-    "hyperdht": "^6.11.0",
-    "@hyper-cmd/lib-net": "https://github.com/holepunchto/hyper-cmd-lib-net#v0.0.8",
     "@hyper-cmd/lib-keys": "https://github.com/holepunchto/hyper-cmd-lib-keys#v0.0.2",
+    "@hyper-cmd/lib-net": "https://github.com/holepunchto/hyper-cmd-lib-net#v0.0.8",
     "@hyper-cmd/lib-utils": "https://github.com/holepunchto/hyper-cmd-lib-utils#v0.0.2",
+    "graceful-goodbye": "^1.3.0",
+    "hyperdht": "^6.11.0",
     "minimist": "^1.2.5"
   },
-  "devDependencies": {},
   "bin": {
     "hypertele-server": "./server.js",
     "hypertele": "./client.js"

--- a/pub.js
+++ b/pub.js
@@ -5,6 +5,7 @@ const argv = require('minimist')(process.argv.slice(2))
 const libNet = require('@hyper-cmd/lib-net')
 const libUtils = require('@hyper-cmd/lib-utils')
 const libKeys = require('@hyper-cmd/lib-keys')
+const goodbye = require('graceful-goodbye')
 const connRemoteCtrl = libNet.connRemoteCtrl
 
 const helpMsg = 'Usage:\nhypertele-pub -l port_local ?-c conf.json ?--seed seed'
@@ -103,6 +104,9 @@ if (debug) {
   }, 5000)
 }
 
-process.once('SIGINT', function () {
-  dht.destroy()
+goodbye(async () => {
+  await new Promise(resolve => {
+    local.close(resolve)
+  })
+  await dht.destroy()
 })

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const argv = require('minimist')(process.argv.slice(2))
 const libNet = require('@hyper-cmd/lib-net')
 const libUtils = require('@hyper-cmd/lib-utils')
 const libKeys = require('@hyper-cmd/lib-keys')
+const goodbye = require('graceful-goodbye')
 const connPiper = libNet.connPiper
 
 const helpMsg = 'Usage:\nhypertele-server -l service_port -u unix_socket ?--address service_address ?-c conf.json ?--seed seed ?--cert-skip'
@@ -91,6 +92,6 @@ if (debug) {
   }, 5000)
 }
 
-process.once('SIGINT', function () {
-  dht.destroy()
+goodbye(async () => {
+  await dht.destroy()
 })


### PR DESCRIPTION
Graceful-goodbye also triggers the exit logic on a SIGTERM (https://github.com/mafintosh/graceful-goodbye/) instead of just SIGINT

I also noticed that the exit-logic for the pub server was incomplete, as it still hung forever due to the local server still running, so I added that to the exit logic
