### PR TITLE
Add --private flag + add some end-to-end tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: Build Status
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1 https://github.com/actions/checkout/releases/tag/v4.1.1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2 https://github.com/actions/setup-node/releases/tag/v3.8.2
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm test

--- a/client.js
+++ b/client.js
@@ -16,7 +16,7 @@ if (argv.help) {
   process.exit(-1)
 }
 
-if (!argv.u && !+argv.p) {
+if (!argv.u && argv.p == null) {
   console.error('Error: proxy port invalid')
   process.exit(-1)
 }
@@ -48,6 +48,12 @@ if (conf.private) {
   keyPair = HyperDHT.keyPair(b4a.from(seed, 'hex'))
 }
 
+// Unofficial opt, only used for tests
+let bootstrap = null
+if (argv.bootstrap) {
+  bootstrap = [{ host: '127.0.0.1', port: argv.bootstrap }]
+}
+
 if (argv.s) {
   conf.peer = conf.private
     ? keyPair.publicKey
@@ -76,6 +82,7 @@ const debug = argv.debug
 const stats = {}
 
 const dht = new HyperDHT({
+  bootstrap,
   keyPair
 })
 
@@ -101,7 +108,8 @@ if (argv.u) {
 } else {
   const targetHost = argv.address || '127.0.0.1'
   proxy.listen(target, targetHost, () => {
-    console.log(`Server ready @${targetHost}:${target}`)
+    const { address, port } = proxy.address()
+    console.log(`Server ready @${address}:${port}`)
   })
 }
 

--- a/end-to-end-tests.js
+++ b/end-to-end-tests.js
@@ -1,0 +1,155 @@
+const { spawn } = require('node:child_process')
+const { once } = require('node:events')
+const http = require('http')
+const createTestnet = require('hyperdht/testnet')
+const test = require('brittle')
+const HyperDHT = require('hyperdht')
+const b4a = require('b4a')
+
+test('Can proxy in private mode', async t => {
+  const { bootstrap } = await createTestnet(3, t.teardown)
+  const portToProxy = await setupDummyServer(t.teardown)
+  const seed = 'a'.repeat(64)
+
+  await setupHyperteleServer(portToProxy, seed, bootstrap, t, { isPrivate: true })
+  const clientPort = await setupHyperteleClient(seed, bootstrap, t, { isPrivate: true })
+
+  const res = await request(clientPort)
+  t.is(res.data, 'You got served', 'Proxy works')
+})
+
+test('Cannot access private-mode server with public key', async t => {
+  const { bootstrap } = await createTestnet(3, t.teardown)
+  const portToProxy = await setupDummyServer(t.teardown)
+  const seed = 'a'.repeat(64)
+  const keypair = HyperDHT.keyPair(b4a.from(seed, 'hex'))
+  const pubKey = b4a.toString(keypair.publicKey, 'hex')
+
+  await setupHyperteleServer(portToProxy, seed, bootstrap, t, { isPrivate: true })
+  const clientPort = await setupHyperteleClient(pubKey, bootstrap, t, { isPrivate: false })
+
+  // Could also be a socket hangup if more time is given
+  await t.exception(async () => await request(clientPort), /Request timeout/)
+})
+
+test('Can proxy in non-private mode', async t => {
+  const { bootstrap } = await createTestnet(3, t.teardown)
+  const portToProxy = await setupDummyServer(t.teardown)
+  const seed = 'a'.repeat(64)
+  const keypair = HyperDHT.keyPair(b4a.from(seed, 'hex'))
+  const pubKey = b4a.toString(keypair.publicKey, 'hex')
+
+  await setupHyperteleServer(portToProxy, seed, bootstrap, t, { isPrivate: false })
+  const clientPort = await setupHyperteleClient(pubKey, bootstrap, t, { isPrivate: false })
+
+  const res = await request(clientPort)
+  t.is(res.data, 'You got served', 'Proxy works')
+})
+
+async function setupDummyServer (teardown) {
+  const server = http.createServer(async (req, res) => {
+    res.setHeader('Content-Type', 'text/html; charset=utf-8')
+    res.end('You got served')
+  })
+  teardown(() => server.close())
+
+  server.listen({ port: 0, host: '127.0.0.1' })
+  await once(server, 'listening')
+  return server.address().port
+}
+
+async function setupHyperteleServer (portToProxy, seed, bootstrap, t, { isPrivate = false } = {}) {
+  const args = [
+    './server.js',
+    '-l',
+    portToProxy,
+    '--seed',
+    seed,
+    '--bootstrap',
+    bootstrap[0].port
+  ]
+  if (isPrivate) args.push('--private')
+
+  const setupServer = spawn('node', args)
+  t.teardown(() => setupServer.kill('SIGKILL'))
+
+  setupServer.stderr.on('data', (data) => {
+    console.error(data.toString())
+    t.fail('Failed to setup hypertele server')
+  })
+
+  await new Promise(resolve => {
+    setupServer.stdout.on('data', (data) => {
+      if (data.includes('hypertele')) {
+        resolve()
+      }
+    })
+  })
+}
+
+async function setupHyperteleClient (seed, bootstrap, t, { isPrivate = false } = {}) {
+  const args = [
+    './client.js',
+    '-p',
+    0, // random
+    '-s',
+    seed,
+    '--bootstrap',
+    bootstrap[0].port
+  ]
+  if (isPrivate) args.push('--private')
+
+  const setupClient = spawn('node', args)
+  t.teardown(() => setupClient.kill('SIGKILL'))
+
+  setupClient.stderr.on('data', (data) => {
+    console.error(data.toString())
+    t.fail('Failed to setup hypertele client')
+  })
+
+  const clientPort = await new Promise(resolve => {
+    setupClient.stdout.on('data', (data) => {
+      const msg = data.toString()
+      if (msg.includes('Server ready')) {
+        const port = msg.slice(msg.search(':') + 1)
+        resolve(port)
+      }
+    })
+  })
+
+  return clientPort
+}
+
+async function request (port, { msTimeout = 500 } = {}) {
+  const link = `http://127.0.0.1:${port}`
+
+  return new Promise((resolve, reject) => {
+    const req = http.get(link, {
+      headers: {
+        Connection: 'close'
+      }
+    })
+
+    req.setTimeout(msTimeout,
+      () => {
+        reject(new Error('Request timeout'))
+        req.destroy()
+      }
+    )
+
+    req.on('error', reject)
+    req.on('response', function (res) {
+      let buf = ''
+
+      res.setEncoding('utf-8')
+
+      res.on('data', function (data) {
+        buf += data
+      })
+
+      res.on('end', function () {
+        resolve({ status: res.statusCode, data: buf })
+      })
+    })
+  })
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "standard": "^17.1.0"
   },
   "scripts": {
-    "test": "standard && brittle end-to-end-tests.js"
+    "test": "standard && brittle test/end-to-end-tests.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "bugs": {
     "url": "https://github.com/bitfinexcom/hypertele/issues"
   },
-  "homepage": "https://github.com/bitfinexcom/hypertele"
+  "homepage": "https://github.com/bitfinexcom/hypertele",
+  "devDependencies": {
+    "brittle": "^3.3.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@hyper-cmd/lib-keys": "https://github.com/holepunchto/hyper-cmd-lib-keys#v0.0.2",
     "@hyper-cmd/lib-net": "https://github.com/holepunchto/hyper-cmd-lib-net#v0.0.8",
     "@hyper-cmd/lib-utils": "https://github.com/holepunchto/hyper-cmd-lib-utils#v0.0.2",
+    "b4a": "^1.6.4",
     "graceful-goodbye": "^1.3.0",
     "hyperdht": "^6.11.0",
     "minimist": "^1.2.5"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
   },
   "homepage": "https://github.com/bitfinexcom/hypertele",
   "devDependencies": {
-    "brittle": "^3.3.2"
+    "brittle": "^3.3.2",
+    "standard": "^17.1.0"
+  },
+  "scripts": {
+    "test": "standard && brittle end-to-end-tests.js"
   }
 }

--- a/server.js
+++ b/server.js
@@ -59,11 +59,17 @@ if (argv.private) {
   conf.private = true
 }
 
+// Unofficial opt, only used for tests
+let bootstrap = null
+if (argv.bootstrap) {
+  bootstrap = [{ host: '127.0.0.1', port: argv.bootstrap }]
+}
+
 const debug = argv.debug
 
 const seed = Buffer.from(conf.seed, 'hex')
 
-const dht = new HyperDHT()
+const dht = new HyperDHT({ bootstrap })
 const keyPair = HyperDHT.keyPair(seed)
 
 const stats = {}

--- a/test/end-to-end-tests.js
+++ b/test/end-to-end-tests.js
@@ -1,10 +1,15 @@
-const { spawn } = require('node:child_process')
-const { once } = require('node:events')
+const { spawn } = require('child_process')
+const { once } = require('events')
+const path = require('path')
 const http = require('http')
 const createTestnet = require('hyperdht/testnet')
 const test = require('brittle')
 const HyperDHT = require('hyperdht')
 const b4a = require('b4a')
+
+const MAIN_DIR = path.dirname(__dirname)
+const SERVER_EXECUTABLE = path.join(MAIN_DIR, 'server.js')
+const CLIENT_EXECUTABLE = path.join(MAIN_DIR, 'client.js')
 
 test('Can proxy in private mode', async t => {
   const { bootstrap } = await createTestnet(3, t.teardown)
@@ -60,7 +65,7 @@ async function setupDummyServer (teardown) {
 
 async function setupHyperteleServer (portToProxy, seed, bootstrap, t, { isPrivate = false } = {}) {
   const args = [
-    './server.js',
+    SERVER_EXECUTABLE,
     '-l',
     portToProxy,
     '--seed',
@@ -89,7 +94,7 @@ async function setupHyperteleServer (portToProxy, seed, bootstrap, t, { isPrivat
 
 async function setupHyperteleClient (seed, bootstrap, t, { isPrivate = false } = {}) {
   const args = [
-    './client.js',
+    CLIENT_EXECUTABLE,
     '-p',
     0, // random
     '-s',


### PR DESCRIPTION
Adds a --private option for the client and server, ensuring that access to whatever is proxied doesn't leak to the DHT. It uses the same approach as hyperbeam, where both peers use the same identity (https://github.com/holepunchto/hyperbeam/)

I also added some end-to-end tests, which required a few additional changes. I can PR a version with just the --private option if you prefer (from here https://github.com/bitfinexcom/hypertele/compare/main...HDegroote:hypertele:add-private-mode)

Additional changes for the tests:
- Client and server support a hidden --bootstrap option, so a testnet can be used
- Client allows specifying a 0-port for dynamic port assignment
- The client's server uses `proxy.address()` to get the port and host, instead of using the passed-in values

