### PR TITLE
Always set keetAlive

### DIFF
--- a/client.js
+++ b/client.js
@@ -84,14 +84,13 @@ const stats = {}
 
 const dht = new HyperDHT({
   bootstrap,
-  keyPair
+  keyPair,
+  connectionKeepAlive: conf.keepAlive
 })
 
 const proxy = net.createServer({ allowHalfOpen: true }, c => {
   return connPiper(c, () => {
     const stream = dht.connect(Buffer.from(peer, 'hex'), { reusableSocket: true })
-    stream.setKeepAlive(conf.keepAlive)
-
     return stream
   }, { compress: conf.compress }, stats)
 })

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@hyper-cmd/lib-utils": "https://github.com/holepunchto/hyper-cmd-lib-utils#v0.0.2",
     "b4a": "^1.6.4",
     "graceful-goodbye": "^1.3.0",
-    "hyperdht": "^6.11.0",
+    "hyperdht": "holepunchto/hyperdht#keep-alive-opt",
     "minimist": "^1.2.5"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@hyper-cmd/lib-utils": "https://github.com/holepunchto/hyper-cmd-lib-utils#v0.0.2",
     "b4a": "^1.6.4",
     "graceful-goodbye": "^1.3.0",
-    "hyperdht": "holepunchto/hyperdht#keep-alive-opt",
+    "hyperdht": "^6.14.0",
     "minimist": "^1.2.5"
   },
   "bin": {

--- a/pub.js
+++ b/pub.js
@@ -21,6 +21,7 @@ if (!+argv.l) {
 }
 
 const conf = {}
+conf.keepAlive = 5000
 
 if (argv.seed) {
   conf.seed = argv.seed
@@ -51,7 +52,7 @@ const debug = argv.debug
 
 const seed = Buffer.from(conf.seed, 'hex')
 
-const dht = new HyperDHT()
+const dht = new HyperDHT({ connectionKeepAlive: conf.keepAlive })
 const keyPair = HyperDHT.keyPair(seed)
 
 const stats = { cid: 0 }

--- a/server.js
+++ b/server.js
@@ -27,6 +27,7 @@ if (argv.u && argv.l) {
 }
 
 const conf = {}
+conf.keepAlive = 5000
 
 if (argv.seed) {
   conf.seed = argv.seed
@@ -69,7 +70,11 @@ const debug = argv.debug
 
 const seed = Buffer.from(conf.seed, 'hex')
 
-const dht = new HyperDHT({ bootstrap })
+const dht = new HyperDHT({
+  bootstrap,
+  connectionKeepAlive: conf.keepAlive
+})
+
 const keyPair = HyperDHT.keyPair(seed)
 
 const stats = {}


### PR DESCRIPTION
Previously only the client was setting a keepAlive. Now also the server does it.

Note: I didn't expose keepAlive as an arg for now (just defaulting to 5s), but can do so if already relevant for some use case
Note: updated the client to also use hyperdht's new connectionKeepAlive opt, so it uses the same API as the server
