### PR TITLE
(tests) Add more time before timeout on request

### DIFF
--- a/test/end-to-end-tests.js
+++ b/test/end-to-end-tests.js
@@ -125,7 +125,7 @@ async function setupHyperteleClient (seed, bootstrap, t, { isPrivate = false } =
   return clientPort
 }
 
-async function request (port, { msTimeout = 500 } = {}) {
+async function request (port, { msTimeout = 5000 } = {}) {
   const link = `http://127.0.0.1:${port}`
 
   return new Promise((resolve, reject) => {

--- a/test/end-to-end-tests.js
+++ b/test/end-to-end-tests.js
@@ -34,7 +34,7 @@ test('Cannot access private-mode server with public key', async t => {
   const clientPort = await setupHyperteleClient(pubKey, bootstrap, t, { isPrivate: false })
 
   // Could also be a socket hangup if more time is given
-  await t.exception(async () => await request(clientPort), /Request timeout/)
+  await t.exception(async () => await request(clientPort, { msTimeout: 1000 }), /Request timeout/)
 })
 
 test('Can proxy in non-private mode', async t => {


### PR DESCRIPTION
Occasionally the request takes a few 100ms, so this PR adds some more margin to avoid flakiness